### PR TITLE
Use ctx from errgroup

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -155,7 +155,8 @@ func LoadMetadata(ctx context.Context, metadataFields MetadataField) (*Metadata,
 		ServiceAccountEmail: serviceAccountEmail,
 	}
 
-	var g errgroup.Group
+	g, ctx := errgroup.WithContext(ctx)
+
 	if cfg.ProjectID == "" && metadataFields&MetadataProjectID != 0 {
 		g.Go(func() error {
 			projectID, err := metadata.ProjectIDWithContext(ctx)


### PR DESCRIPTION
Use the context mechanism provided by `errgroup` to synchronize execution across all goroutine in the error group.