### PR TITLE
Simplify environment variable handling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,11 @@ The following environment variables are supported by default:
 - Service Account Email: `GOOGLE_SERVICE_ACCOUNT_EMAIL`
 
 You can customize which environment variables are checked by modifying the
-`Env*` package variables. Each variable can be set to either a single
-environment variable name (string) or a list of fallback variables ([]string)
-that will be checked in order until a non-empty value is found. If no non-empty
-environment variables are found and the loader is configured to fetch the
-corresponding metadata field, the value will be fetched from the metadata
-server.
+`Env*` package variables. Each variable can be set to a list of fallback
+variables ([]string) that will be checked in order until a non-empty value is
+found. If no non-empty environment variables are found and the loader is
+configured to fetch the corresponding metadata field, the value will be fetched
+from the metadata server.
 
 
 ## Error Handling

--- a/metadata.go
+++ b/metadata.go
@@ -38,54 +38,38 @@ const (
 )
 
 var (
-	// EnvProjectID specifies environment variables for the project ID.
-	// This can be a single environment variable name or a list of fallback
-	// variables that will be checked in order. The first non-empty value found
-	// will be used to override the project ID retrieved from the metadata
-	// server.
+	// EnvProjectID is a list of environment variable names that can override
+	// the project ID from the metadata server. Variables are checked in order,
+	// with the first non-empty value taking precedence.
 	EnvProjectID = []string{"CLOUDSDK_CORE_PROJECT", "GOOGLE_CLOUD_PROJECT", "GCP_PROJECT_ID"}
 
-	// EnvProjectNumber specifies environment variables for the project number.
-	// This can be a single environment variable name or a list of fallback
-	// variables that will be checked in order. The first non-empty value found
-	// will be used to override the project number retrieved from the metadata
-	// server.
-	EnvProjectNumber = "GCP_PROJECT_NUMBER"
+	// EnvProjectNumber is a list of environment variable names that can
+	// override the project number from the metadata server. Variables are
+	// checked in order, with the first non-empty value taking precedence.
+	EnvProjectNumber = []string{"GCP_PROJECT_NUMBER"}
 
-	// EnvRegion specifies environment variables for the Cloud Run region.
-	// This can be a single environment variable name or a list of fallback
-	// variables that will be checked in order. The first non-empty value found
-	// will be used to override the region retrieved from the metadata server.
+	// EnvRegion is a list of environment variable names that can override
+	// the region from the metadata server. Variables are checked in order,
+	// with the first non-empty value taking precedence.
 	EnvRegion = []string{"CLOUDSDK_COMPUTE_REGION", "GCP_REGION"}
 
-	// EnvInstanceID specifies environment variables for the instance ID.
-	// This can be a single environment variable name or a list of fallback
-	// variables that will be checked in order. The first non-empty value found
-	// will be used to override the instance ID retrieved from the metadata
-	// server.
-	EnvInstanceID = "CLOUD_RUN_INSTANCE_ID"
+	// EnvInstanceID is a list of environment variable names that can override
+	// the instance ID from the metadata server. Variables are checked in order,
+	// with the first non-empty value taking precedence.
+	EnvInstanceID = []string{"CLOUD_RUN_INSTANCE_ID"}
 
-	// EnvServiceAccountEmail specifies environment variables for the service
-	// account email. This can be a single environment variable name or a list
-	// of fallback variables that will be checked in order. The first non-empty
-	// value found will be used to override the service account email retrieved
-	// from the metadata server.
-	EnvServiceAccountEmail = "GOOGLE_SERVICE_ACCOUNT_EMAIL"
+	// EnvServiceAccountEmail is a list of environment variable names that can
+	// override the service account email from the metadata server. Variables
+	// are checked in order, with the first non-empty value taking precedence.
+	EnvServiceAccountEmail = []string{"GOOGLE_SERVICE_ACCOUNT_EMAIL"}
 )
 
-// getEnv retrieves environment variable values from a string or []string.
-// For a string input, it returns the value of that environment variable.
-// For a []string input, it checks each environment variable in order and
-// returns the first non-empty value found. If no value is found, returns
-// an empty string.
-func getEnv[T string | []string](key T) string {
-	if v, ok := any(key).(string); ok {
-		return os.Getenv(v)
-	}
-
-	for _, v := range any(key).([]string) {
-		val := os.Getenv(v)
-		if val != "" {
+// getEnv retrieves environment variable values from a list of environment
+// variable names. It checks each environment variable in order and returns the
+// first non-empty value found. If no value is found, returns an empty string.
+func getEnv(key []string) string {
+	for _, v := range key {
+		if val := os.Getenv(v); val != "" {
 			return val
 		}
 	}
@@ -122,18 +106,12 @@ type Metadata struct {
 // to fetch from the metadata server - if a field is not requested and not set
 // via environment variables, it will remain empty in the returned struct.
 func LoadMetadata(ctx context.Context, metadataFields MetadataField) (*Metadata, error) {
-	projectID := getEnv(EnvProjectID)
-	projectNumber := getEnv(EnvProjectNumber)
-	region := getEnv(EnvRegion)
-	instanceID := getEnv(EnvInstanceID)
-	serviceAccountEmail := getEnv(EnvServiceAccountEmail)
-
 	cfg := Metadata{
-		ProjectID:           projectID,
-		ProjectNumber:       projectNumber,
-		Region:              region,
-		InstanceID:          instanceID,
-		ServiceAccountEmail: serviceAccountEmail,
+		ProjectID:           getEnv(EnvProjectID),
+		ProjectNumber:       getEnv(EnvProjectNumber),
+		Region:              getEnv(EnvRegion),
+		InstanceID:          getEnv(EnvInstanceID),
+		ServiceAccountEmail: getEnv(EnvServiceAccountEmail),
 	}
 
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
This pull request updates the handling of environment variables in the `metadata` package to simplify and standardize their usage. The changes include modifying environment variable definitions to always use lists of fallback variables, updating the `getEnv` function to reflect this change, and simplifying the `LoadMetadata` function.

### Standardization of environment variable handling:

* Updated all environment variable definitions (e.g., `EnvProjectID`, `EnvProjectNumber`, `EnvRegion`, etc.) to use lists of fallback variables instead of supporting single string values. This ensures consistent behavior across all variables. (`metadata.go`, [metadata.goL41-R72](diffhunk://#diff-a8d12f1d7ad57b8d9b990ae8f5ca23a5a4673b4c513d1457f6896417dc2e00ddL41-R72))
* Simplified the `getEnv` function to only handle lists of environment variable names, removing support for single string inputs. (`metadata.go`, [metadata.goL41-R72](diffhunk://#diff-a8d12f1d7ad57b8d9b990ae8f5ca23a5a4673b4c513d1457f6896417dc2e00ddL41-R72))

### Simplification of metadata loading:

* Refactored the `LoadMetadata` function to directly use the updated `getEnv` function for retrieving environment variable values, reducing intermediate variable assignments. (`metadata.go`, [metadata.goL125-R114](diffhunk://#diff-a8d12f1d7ad57b8d9b990ae8f5ca23a5a4673b4c513d1457f6896417dc2e00ddL125-R114))

### Documentation updates:

* Updated the `README.md` to reflect the changes in how environment variables are defined and used, clarifying that all variables are now lists of fallback options. (`README.md`, [README.mdL109-R113](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R113))