### PR TITLE
Add support for sethvargo/go-envconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ and metadata server information in Cloud Run environments.
 - Concurrent metadata fetching for better performance
 - Configurable metadata field loading
 - Reload configuration at any time
+- Integration with [sethvargo/go-envconfig](https://github.com/sethvargo/go-envconfig)
 
 ## Installation
 
@@ -66,7 +67,7 @@ cfg, err := runcfg.LoadService(
 import "github.com/joaopenteado/runcfg"
 
 func main() {
-    // Load job configuration
+    // Load job configuration with default options
     cfg, err := runcfg.LoadJob()
     if err != nil {
         log.Fatal(err)

--- a/job.go
+++ b/job.go
@@ -1,86 +1,16 @@
 package runcfg
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strconv"
 )
 
-type jobLoadOptions struct {
-	defaultName        string
-	defaultExecution   string
-	defaultTaskIndex   uint
-	defaultTaskAttempt uint
-	defaultTaskCount   uint
-}
-
-func defaultJobLoadOptions() jobLoadOptions {
-	return jobLoadOptions{
-		defaultName:        "",
-		defaultExecution:   "",
-		defaultTaskIndex:   0,
-		defaultTaskAttempt: 0,
-		defaultTaskCount:   1,
-	}
-}
-
-type JobLoadOption func(*jobLoadOptions)
-
-// WithDefaultJobName specifies the default name to use if the CLOUD_RUN_JOB
-// environment variable is not set. If multiple names are provided, the first
-// non-empty name will be used.
-func WithDefaultJobName(names ...string) JobLoadOption {
-	return func(o *jobLoadOptions) {
-		for _, name := range names {
-			if name != "" {
-				o.defaultName = name
-				break
-			}
-		}
-	}
-}
-
-// WithDefaultExecution specifies the default execution name to use if the
-// CLOUD_RUN_EXECUTION environment variable is not set. If multiple execution
-// names are provided, the first non-empty execution name will be used.
-func WithDefaultExecution(executions ...string) JobLoadOption {
-	return func(o *jobLoadOptions) {
-		for _, execution := range executions {
-			if execution != "" {
-				o.defaultExecution = execution
-				break
-			}
-		}
-	}
-}
-
-// WithDefaultTaskIndex specifies the default task index to use if the
-// CLOUD_RUN_TASK_INDEX environment variable is not set.
-func WithDefaultTaskIndex(taskIndex uint) JobLoadOption {
-	return func(o *jobLoadOptions) {
-		o.defaultTaskIndex = taskIndex
-	}
-}
-
-// WithDefaultTaskAttempt specifies the default task attempt to use if the
-// CLOUD_RUN_TASK_ATTEMPT environment variable is not set.
-func WithDefaultTaskAttempt(taskAttempt uint) JobLoadOption {
-	return func(o *jobLoadOptions) {
-		o.defaultTaskAttempt = taskAttempt
-	}
-}
-
-// WithDefaultTaskCount specifies the default task count to use if the
-// CLOUD_RUN_TASK_COUNT environment variable is not set.
-func WithDefaultTaskCount(taskCount uint) JobLoadOption {
-	return func(o *jobLoadOptions) {
-		o.defaultTaskCount = taskCount
-	}
-}
-
 // Job contains environment variables available to Cloud Run jobs.
-// For more details see:
-// https://cloud.google.com/run/docs/container-contract#services-env-vars
+// For more details see the [container runtime contract for Jobs].
+//
+// [container runtime contract for Jobs]: https://cloud.google.com/run/docs/container-contract#jobs-env-vars
 type Job struct {
 	// Name is the name of the Cloud Run job being run.
 	// Read from `CLOUD_RUN_JOB` environment variable.
@@ -110,31 +40,98 @@ type Job struct {
 	TaskCount uint
 }
 
+func defaultJob() *Job {
+	return &Job{
+		TaskCount: 1,
+	}
+}
+
+type JobLoadOption func(*Job)
+
+// WithDefaultJobName specifies the default name to use if the CLOUD_RUN_JOB
+// environment variable is not set. If multiple names are provided, the first
+// non-empty name will be used.
+func WithDefaultJobName(names ...string) JobLoadOption {
+	return func(o *Job) {
+		for _, name := range names {
+			if name != "" {
+				o.Name = name
+				break
+			}
+		}
+	}
+}
+
+// WithDefaultExecution specifies the default execution name to use if the
+// CLOUD_RUN_EXECUTION environment variable is not set. If multiple execution
+// names are provided, the first non-empty execution name will be used.
+func WithDefaultExecution(executions ...string) JobLoadOption {
+	return func(o *Job) {
+		for _, execution := range executions {
+			if execution != "" {
+				o.Execution = execution
+				break
+			}
+		}
+	}
+}
+
+// WithDefaultTaskIndex specifies the default task index to use if the
+// CLOUD_RUN_TASK_INDEX environment variable is not set.
+func WithDefaultTaskIndex(taskIndex uint) JobLoadOption {
+	return func(o *Job) {
+		o.TaskIndex = taskIndex
+	}
+}
+
+// WithDefaultTaskAttempt specifies the default task attempt to use if the
+// CLOUD_RUN_TASK_ATTEMPT environment variable is not set.
+func WithDefaultTaskAttempt(taskAttempt uint) JobLoadOption {
+	return func(o *Job) {
+		o.TaskAttempt = taskAttempt
+	}
+}
+
+// WithDefaultTaskCount specifies the default task count to use if the
+// CLOUD_RUN_TASK_COUNT environment variable is not set.
+func WithDefaultTaskCount(taskCount uint) JobLoadOption {
+	return func(o *Job) {
+		o.TaskCount = taskCount
+	}
+}
+
 // LoadJob loads configuration for a Cloud Run job from environment variables.
 // It returns a Job containing the loaded configuration or ErrEnvironmentProcess
-// if environment variable processing fails.
+// if environment variable processing fails. Use options to specify default
+// values for the job.
 func LoadJob(opts ...JobLoadOption) (*Job, error) {
-	j := &Job{}
-	return j, j.Reload(opts...)
+	// Default values
+	j := defaultJob()
+
+	// Apply options
+	for _, opt := range opts {
+		opt(j)
+	}
+
+	// Reload configuration from the environment
+	if err := j.Reload(); err != nil {
+		return nil, err
+	}
+
+	return j, nil
 }
 
 // Reload reloads the configuration for a Cloud Run job from environment
 // variables. It returns ErrEnvironmentProcess if environment variable
-// processing fails.
-func (j *Job) Reload(opts ...JobLoadOption) error {
-	loadOpts := defaultJobLoadOptions()
-	for _, opt := range opts {
-		opt(&loadOpts)
+// processing fails. It does not overwrite values already set in the Job
+// struct if they are not set in the environment.
+func (j *Job) Reload() error {
+	if name := os.Getenv("CLOUD_RUN_JOB"); name != "" {
+		j.Name = name
 	}
 
-	j.Name = os.Getenv("CLOUD_RUN_JOB")
-	j.Execution = os.Getenv("CLOUD_RUN_EXECUTION")
-
-	if j.Name == "" {
-		j.Name = loadOpts.defaultName
-	}
-	if j.Execution == "" {
-		j.Execution = loadOpts.defaultExecution
+	if execution := os.Getenv("CLOUD_RUN_EXECUTION"); execution != "" {
+		j.Execution = execution
 	}
 
 	if taskIdx := os.Getenv("CLOUD_RUN_TASK_INDEX"); taskIdx != "" {
@@ -143,8 +140,6 @@ func (j *Job) Reload(opts ...JobLoadOption) error {
 			return errors.Join(ErrEnvironmentProcess, errors.New("invalid CLOUD_RUN_TASK_INDEX value"), err)
 		}
 		j.TaskIndex = uint(idx)
-	} else {
-		j.TaskIndex = loadOpts.defaultTaskIndex
 	}
 
 	if taskAttempt := os.Getenv("CLOUD_RUN_TASK_ATTEMPT"); taskAttempt != "" {
@@ -153,8 +148,6 @@ func (j *Job) Reload(opts ...JobLoadOption) error {
 			return errors.Join(ErrEnvironmentProcess, errors.New("invalid CLOUD_RUN_TASK_ATTEMPT value"), err)
 		}
 		j.TaskAttempt = uint(attempt)
-	} else {
-		j.TaskAttempt = loadOpts.defaultTaskAttempt
 	}
 
 	if taskCount := os.Getenv("CLOUD_RUN_TASK_COUNT"); taskCount != "" {
@@ -163,9 +156,32 @@ func (j *Job) Reload(opts ...JobLoadOption) error {
 			return errors.Join(ErrEnvironmentProcess, errors.New("invalid CLOUD_RUN_TASK_COUNT value"), err)
 		}
 		j.TaskCount = uint(count)
-	} else {
-		j.TaskCount = loadOpts.defaultTaskCount
 	}
 
 	return nil
+}
+
+// EnvDecode implements the [envconfig.DecoderCtx] interface from
+// github.com/sethvargo/go-envconfig. This ensures that [envconfig.Process] will
+// return errors derived from [ErrEnvironmentProcess] if the environment
+// variables are invalid.
+//
+// The behavior of this function is equivalent to initializing a Job with
+// the default values and then calling [Job.Reload]. However, values already
+// set in the Job struct prior to calling this function are not overridden
+// by the defaults, only by the reloaded values from the environment.
+//
+// [envconfig.DecoderCtx]: https://pkg.go.dev/github.com/sethvargo/go-envconfig#DecoderCtx
+// [envconfig.Process]: https://pkg.go.dev/github.com/sethvargo/go-envconfig#Process
+func (j *Job) EnvDecode(ctx context.Context, val string) error {
+	defaults := defaultJob()
+
+	// Name, Execution, TaskIndex and TaskAttempt default values are zero and
+	// can be skipped.
+
+	if j.TaskCount == 0 {
+		j.TaskCount = defaults.TaskCount
+	}
+
+	return j.Reload()
 }

--- a/metadata.go
+++ b/metadata.go
@@ -288,35 +288,57 @@ func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField) err
 // return errors derived from [ErrMetadataFetch] if the metadata server is
 // unavailable.
 //
-// The behavior of this function is equivalent to initializing a Metadata with
-// the default values and then calling [Metadata.Reload]. However, values already
-// set in the Metadata struct prior to calling this function are not overridden
-// by the defaults, only by the reloaded values from the environment.
+// The behavior of this function is equivalent to initializing a Metadata struct
+// with the default values and then calling [Metadata.Reload] with values unset
+// from the environment. Values already set in the Metadata struct prior to
+// calling this function are not overridden by the defaults nor fetched from
+// the metadata server.
 //
 // [envconfig.DecoderCtx]: https://pkg.go.dev/github.com/sethvargo/go-envconfig#DecoderCtx
 // [envconfig.Process]: https://pkg.go.dev/github.com/sethvargo/go-envconfig#Process
 func (m *Metadata) EnvDecode(ctx context.Context, val string) error {
+	metadataFields := MetadataNone
 	defaults := defaultMetadata()
 
 	if m.ProjectID == "" {
-		m.ProjectID = defaults.ProjectID
+		if defaults.ProjectID != "" {
+			m.ProjectID = defaults.ProjectID
+		} else {
+			metadataFields |= MetadataProjectID
+		}
 	}
 
 	if m.ProjectNumber == "" {
-		m.ProjectNumber = defaults.ProjectNumber
+		if defaults.ProjectNumber != "" {
+			m.ProjectNumber = defaults.ProjectNumber
+		} else {
+			metadataFields |= MetadataProjectNumber
+		}
 	}
 
 	if m.Region == "" {
-		m.Region = defaults.Region
+		if defaults.Region != "" {
+			m.Region = defaults.Region
+		} else {
+			metadataFields |= MetadataRegion
+		}
 	}
 
 	if m.InstanceID == "" {
-		m.InstanceID = defaults.InstanceID
+		if defaults.InstanceID != "" {
+			m.InstanceID = defaults.InstanceID
+		} else {
+			metadataFields |= MetadataInstanceID
+		}
 	}
 
 	if m.ServiceAccountEmail == "" {
-		m.ServiceAccountEmail = defaults.ServiceAccountEmail
+		if defaults.ServiceAccountEmail != "" {
+			m.ServiceAccountEmail = defaults.ServiceAccountEmail
+		} else {
+			metadataFields |= MetadataServiceAccountEmail
+		}
 	}
 
-	return m.Reload(ctx, MetadataAll)
+	return m.Reload(ctx, metadataFields)
 }

--- a/metadata.go
+++ b/metadata.go
@@ -73,96 +73,6 @@ var (
 	EnvServiceAccountEmail = []string{"GOOGLE_SERVICE_ACCOUNT_EMAIL"}
 )
 
-type metadataLoadOptions struct {
-	defaultProjectID           string
-	defaultProjectNumber       string
-	defaultRegion              string
-	defaultInstanceID          string
-	defaultServiceAccountEmail string
-}
-
-func defaultMetadataLoadOptions() metadataLoadOptions {
-	return metadataLoadOptions{
-		defaultProjectID:           GetFirstEnv(EnvProjectID...),
-		defaultProjectNumber:       GetFirstEnv(EnvProjectNumber...),
-		defaultRegion:              GetFirstEnv(EnvRegion...),
-		defaultInstanceID:          GetFirstEnv(EnvInstanceID...),
-		defaultServiceAccountEmail: GetFirstEnv(EnvServiceAccountEmail...),
-	}
-}
-
-type MetadataLoadOption func(*metadataLoadOptions)
-
-// WithDefaultProjectID specifies the default project ID to use if the
-// environment variable is not set. If multiple project IDs are provided, the
-// first non-empty project ID will be used.
-func WithDefaultProjectID(projectIDs ...string) MetadataLoadOption {
-	return func(o *metadataLoadOptions) {
-		for _, projectID := range projectIDs {
-			if projectID != "" {
-				o.defaultProjectID = projectID
-				break
-			}
-		}
-	}
-}
-
-// WithDefaultProjectNumber specifies the default project number to use if the
-// environment variable is not set. If multiple project numbers are provided,
-// the first non-empty project number will be used.
-func WithDefaultProjectNumber(projectNumbers ...string) MetadataLoadOption {
-	return func(o *metadataLoadOptions) {
-		for _, projectNumber := range projectNumbers {
-			if projectNumber != "" {
-				o.defaultProjectNumber = projectNumber
-				break
-			}
-		}
-	}
-}
-
-// WithDefaultRegion specifies the default region to use if the environment
-// variable is not set. If multiple regions are provided, the first non-empty
-// region will be used.
-func WithDefaultRegion(regions ...string) MetadataLoadOption {
-	return func(o *metadataLoadOptions) {
-		for _, region := range regions {
-			if region != "" {
-				o.defaultRegion = region
-				break
-			}
-		}
-	}
-}
-
-// WithDefaultInstanceID specifies the default instance ID to use if the
-// environment variable is not set. If multiple instance IDs are provided, the
-// first non-empty instance ID will be used.
-func WithDefaultInstanceID(instanceIDs ...string) MetadataLoadOption {
-	return func(o *metadataLoadOptions) {
-		for _, instanceID := range instanceIDs {
-			if instanceID != "" {
-				o.defaultInstanceID = instanceID
-				break
-			}
-		}
-	}
-}
-
-// WithDefaultServiceAccountEmail specifies the default service account email
-// to use if the environment variable is not set. If multiple service account
-// emails are provided, the first non-empty service account email will be used.
-func WithDefaultServiceAccountEmail(serviceAccountEmails ...string) MetadataLoadOption {
-	return func(o *metadataLoadOptions) {
-		for _, serviceAccountEmail := range serviceAccountEmails {
-			if serviceAccountEmail != "" {
-				o.defaultServiceAccountEmail = serviceAccountEmail
-				break
-			}
-		}
-	}
-}
-
 // Metadata contains information from the instance metadata server.
 // Cloud Run instances expose a metadata server that provides details about
 // containers, such as project ID, region, instance ID, and service accounts.
@@ -179,11 +89,93 @@ type Metadata struct {
 	// Region of this Cloud Run service.
 	Region string
 
-	// Unique identifier of the instance (also available in logs).
+	// Unique identifier of the instance.
 	InstanceID string
 
 	// ServiceAccountEmail for the service identity of this Cloud Run service.
 	ServiceAccountEmail string
+}
+
+func defaultMetadata() *Metadata {
+	return &Metadata{
+		ProjectID:           GetFirstEnv(EnvProjectID...),
+		ProjectNumber:       GetFirstEnv(EnvProjectNumber...),
+		Region:              GetFirstEnv(EnvRegion...),
+		InstanceID:          GetFirstEnv(EnvInstanceID...),
+		ServiceAccountEmail: GetFirstEnv(EnvServiceAccountEmail...),
+	}
+}
+
+type MetadataLoadOption func(*Metadata)
+
+// WithDefaultProjectID specifies the default project ID to use if the
+// environment variable is not set. If multiple project IDs are provided, the
+// first non-empty project ID will be used.
+func WithDefaultProjectID(projectIDs ...string) MetadataLoadOption {
+	return func(o *Metadata) {
+		for _, projectID := range projectIDs {
+			if projectID != "" {
+				o.ProjectID = projectID
+				break
+			}
+		}
+	}
+}
+
+// WithDefaultProjectNumber specifies the default project number to use if the
+// environment variable is not set. If multiple project numbers are provided,
+// the first non-empty project number will be used.
+func WithDefaultProjectNumber(projectNumbers ...string) MetadataLoadOption {
+	return func(o *Metadata) {
+		for _, projectNumber := range projectNumbers {
+			if projectNumber != "" {
+				o.ProjectNumber = projectNumber
+				break
+			}
+		}
+	}
+}
+
+// WithDefaultRegion specifies the default region to use if the environment
+// variable is not set. If multiple regions are provided, the first non-empty
+// region will be used.
+func WithDefaultRegion(regions ...string) MetadataLoadOption {
+	return func(o *Metadata) {
+		for _, region := range regions {
+			if region != "" {
+				o.Region = region
+				break
+			}
+		}
+	}
+}
+
+// WithDefaultInstanceID specifies the default instance ID to use if the
+// environment variable is not set. If multiple instance IDs are provided, the
+// first non-empty instance ID will be used.
+func WithDefaultInstanceID(instanceIDs ...string) MetadataLoadOption {
+	return func(o *Metadata) {
+		for _, instanceID := range instanceIDs {
+			if instanceID != "" {
+				o.InstanceID = instanceID
+				break
+			}
+		}
+	}
+}
+
+// WithDefaultServiceAccountEmail specifies the default service account email
+// to use if the environment variable is not set. If multiple service account
+// emails are provided, the first non-empty service account email will be used.
+func WithDefaultServiceAccountEmail(serviceAccountEmails ...string) MetadataLoadOption {
+	return func(o *Metadata) {
+		for _, serviceAccountEmail := range serviceAccountEmails {
+			if serviceAccountEmail != "" {
+				o.ServiceAccountEmail = serviceAccountEmail
+				break
+			}
+		}
+	}
 }
 
 // LoadMetadata loads the metadata from the Cloud Run metadata server. It
@@ -198,25 +190,27 @@ type Metadata struct {
 // EnvProjectID, EnvProjectNumber, EnvRegion, EnvInstanceID, and
 // EnvServiceAccountEmail.
 func LoadMetadata(ctx context.Context, metadataFields MetadataField, opts ...MetadataLoadOption) (*Metadata, error) {
-	m := &Metadata{}
-	return m, m.Reload(ctx, metadataFields, opts...)
+	// Default values
+	m := defaultMetadata()
+
+	// Apply options
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	// Reload metadata from the server
+	if err := m.Reload(ctx, metadataFields); err != nil {
+		return nil, err
+	}
+
+	return m, nil
 }
 
 // Reload reloads the metadata from the Cloud Run metadata server.
 // The metadataFields parameter controls which fields to fetch from
-// the metadata server. If a field is not requested and not set via a default
-// value, it will remain empty in the returned struct.
-//
-// By default, values not loaded from the metadata server will be loaded from
-// the first non-empty value of the environment variables listed in
-// EnvProjectID, EnvProjectNumber, EnvRegion, EnvInstanceID, and
-// EnvServiceAccountEmail.
-func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField, opts ...MetadataLoadOption) error {
-	loadOpts := defaultMetadataLoadOptions()
-	for _, opt := range opts {
-		opt(&loadOpts)
-	}
-
+// the metadata server. Fields not requested will not be loaded and won't
+// overwrite values already set in the Metadata struct.
+func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	if metadataFields&MetadataProjectID != 0 {
@@ -228,8 +222,6 @@ func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField, opt
 			m.ProjectID = projectID
 			return nil
 		})
-	} else {
-		m.ProjectID = loadOpts.defaultProjectID
 	}
 
 	// If both project number and region are requested, both will be fetched
@@ -244,7 +236,7 @@ func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField, opt
 			regionName := res[strings.LastIndexByte(res, '/')+1:]
 			m.Region = regionName
 
-			if m.ProjectNumber == "" && metadataFields&MetadataProjectNumber != 0 {
+			if metadataFields&MetadataProjectNumber != 0 {
 				const projectNumberPrefixLen = len("projects/")
 				projectNumber := res[projectNumberPrefixLen : strings.IndexByte(res[projectNumberPrefixLen:], '/')+projectNumberPrefixLen]
 				m.ProjectNumber = projectNumber
@@ -252,7 +244,6 @@ func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField, opt
 			return nil
 		})
 	} else if metadataFields&MetadataProjectNumber != 0 {
-		m.Region = loadOpts.defaultRegion
 		g.Go(func() error {
 			projectNumber, err := metadata.NumericProjectIDWithContext(ctx)
 			if err != nil {
@@ -261,9 +252,6 @@ func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField, opt
 			m.ProjectNumber = projectNumber
 			return nil
 		})
-	} else {
-		m.Region = loadOpts.defaultRegion
-		m.ProjectNumber = loadOpts.defaultProjectNumber
 	}
 
 	if metadataFields&MetadataInstanceID != 0 {
@@ -275,8 +263,6 @@ func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField, opt
 			m.InstanceID = instanceID
 			return nil
 		})
-	} else {
-		m.InstanceID = loadOpts.defaultInstanceID
 	}
 
 	if metadataFields&MetadataServiceAccountEmail != 0 {
@@ -288,8 +274,6 @@ func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField, opt
 			m.ServiceAccountEmail = email
 			return nil
 		})
-	} else {
-		m.ServiceAccountEmail = loadOpts.defaultServiceAccountEmail
 	}
 
 	if err := g.Wait(); err != nil {
@@ -297,4 +281,42 @@ func (m *Metadata) Reload(ctx context.Context, metadataFields MetadataField, opt
 	}
 
 	return nil
+}
+
+// EnvDecode implements the [envconfig.DecoderCtx] interface from
+// github.com/sethvargo/go-envconfig. This ensures that [envconfig.Process] will
+// return errors derived from [ErrMetadataFetch] if the metadata server is
+// unavailable.
+//
+// The behavior of this function is equivalent to initializing a Metadata with
+// the default values and then calling [Metadata.Reload]. However, values already
+// set in the Metadata struct prior to calling this function are not overridden
+// by the defaults, only by the reloaded values from the environment.
+//
+// [envconfig.DecoderCtx]: https://pkg.go.dev/github.com/sethvargo/go-envconfig#DecoderCtx
+// [envconfig.Process]: https://pkg.go.dev/github.com/sethvargo/go-envconfig#Process
+func (m *Metadata) EnvDecode(ctx context.Context, val string) error {
+	defaults := defaultMetadata()
+
+	if m.ProjectID == "" {
+		m.ProjectID = defaults.ProjectID
+	}
+
+	if m.ProjectNumber == "" {
+		m.ProjectNumber = defaults.ProjectNumber
+	}
+
+	if m.Region == "" {
+		m.Region = defaults.Region
+	}
+
+	if m.InstanceID == "" {
+		m.InstanceID = defaults.InstanceID
+	}
+
+	if m.ServiceAccountEmail == "" {
+		m.ServiceAccountEmail = defaults.ServiceAccountEmail
+	}
+
+	return m.Reload(ctx, MetadataAll)
 }

--- a/service.go
+++ b/service.go
@@ -1,106 +1,19 @@
 package runcfg
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"strconv"
 )
 
-type serviceLoadOptions struct {
-	defaultPort          uint16
-	defaultName          string
-	defaultRevision      string
-	defaultConfiguration string
-}
-
-func defaultServiceLoadOptions() serviceLoadOptions {
-	return serviceLoadOptions{
-		defaultPort: 8080,
-	}
-}
-
-type ServiceLoadOption func(*serviceLoadOptions)
-
-// WithDefaultPort specifies the default port to use if the PORT environment
-// variable is not set. By default, Port will be set to 8080 if the environment
-// variable is not set. If multiple ports are provided, the first non-zero port
-// will be used.
-func WithDefaultPort(ports ...uint16) ServiceLoadOption {
-	return func(o *serviceLoadOptions) {
-		for _, port := range ports {
-			if port != 0 {
-				o.defaultPort = port
-				break
-			}
-		}
-	}
-}
-
-// WithDefaultPortString specifies the default port to use if the PORT
-// environment variable is not set. By default, Port will be set to 8080 if the
-// environment variable is not set. If multiple ports are provided, the first
-// non-zero port will be used.
-func WithDefaultPortString(portStrings ...string) ServiceLoadOption {
-	return func(o *serviceLoadOptions) {
-		for _, portString := range portStrings {
-			if portString != "" {
-				port, err := strconv.ParseUint(portString, 10, 16)
-				if err == nil && port != 0 {
-					o.defaultPort = uint16(port)
-					break
-				}
-			}
-		}
-	}
-}
-
-// WithDefaultServiceName specifies the default name to use if the K_SERVICE
-// environment variable is not set. If multiple names are provided, the first
-// non-empty name will be used.
-func WithDefaultServiceName(names ...string) ServiceLoadOption {
-	return func(o *serviceLoadOptions) {
-		for _, name := range names {
-			if name != "" {
-				o.defaultName = name
-				break
-			}
-		}
-	}
-}
-
-// WithDefaultRevision specifies the default revision to use if the K_REVISION
-// environment variable is not set. If multiple revisions are provided, the
-// first non-empty revision will be used.
-func WithDefaultRevision(revisions ...string) ServiceLoadOption {
-	return func(o *serviceLoadOptions) {
-		for _, revision := range revisions {
-			if revision != "" {
-				o.defaultRevision = revision
-				break
-			}
-		}
-	}
-}
-
-// WithDefaultConfiguration specifies the default configuration to use if the
-// K_CONFIGURATION environment variable is not set. If multiple configurations
-// are provided, the first non-empty configuration will be used.
-func WithDefaultConfiguration(configurations ...string) ServiceLoadOption {
-	return func(o *serviceLoadOptions) {
-		for _, configuration := range configurations {
-			if configuration != "" {
-				o.defaultConfiguration = configuration
-				break
-			}
-		}
-	}
-}
-
 // Service contains environment variables available to Cloud Run services.
 // All variables except PORT are available to all containers. The PORT variable
-// is only added to the ingress container. For more details see:
-// https://cloud.google.com/run/docs/container-contract#services-env-vars
+// is only added to the ingress container. For more details see the [container
+// runtime contract for Services].
+//
+// [container runtime contract for Services]: https://cloud.google.com/run/docs/container-contract#services-env-vars
 type Service struct {
 	// The port your HTTP server should listen on.
 	// By default, requests are sent to port 8080.
@@ -120,37 +33,127 @@ type Service struct {
 	Configuration string
 }
 
+func defaultService() *Service {
+	return &Service{
+		Port: 8080,
+	}
+}
+
+type ServiceLoadOption func(*Service)
+
+// WithDefaultPort specifies the default port to use if the PORT environment
+// variable is not set. By default, Port will be set to 8080 if the environment
+// variable is not set. If multiple ports are provided, the first non-zero port
+// will be used.
+func WithDefaultPort(ports ...uint16) ServiceLoadOption {
+	return func(o *Service) {
+		for _, port := range ports {
+			if port != 0 {
+				o.Port = port
+				break
+			}
+		}
+	}
+}
+
+// WithDefaultPortString specifies the default port to use if the PORT
+// environment variable is not set. By default, Port will be set to 8080 if the
+// environment variable is not set. If multiple ports are provided, the first
+// non-zero port will be used.
+func WithDefaultPortString(portStrings ...string) ServiceLoadOption {
+	return func(o *Service) {
+		for _, portString := range portStrings {
+			if portString != "" {
+				port, err := strconv.ParseUint(portString, 10, 16)
+				if err == nil && port != 0 {
+					o.Port = uint16(port)
+					break
+				}
+			}
+		}
+	}
+}
+
+// WithDefaultServiceName specifies the default name to use if the K_SERVICE
+// environment variable is not set. If multiple names are provided, the first
+// non-empty name will be used.
+func WithDefaultServiceName(names ...string) ServiceLoadOption {
+	return func(o *Service) {
+		for _, name := range names {
+			if name != "" {
+				o.Name = name
+				break
+			}
+		}
+	}
+}
+
+// WithDefaultRevision specifies the default revision to use if the K_REVISION
+// environment variable is not set. If multiple revisions are provided, the
+// first non-empty revision will be used.
+func WithDefaultRevision(revisions ...string) ServiceLoadOption {
+	return func(o *Service) {
+		for _, revision := range revisions {
+			if revision != "" {
+				o.Revision = revision
+				break
+			}
+		}
+	}
+}
+
+// WithDefaultConfiguration specifies the default configuration to use if the
+// K_CONFIGURATION environment variable is not set. If multiple configurations
+// are provided, the first non-empty configuration will be used.
+func WithDefaultConfiguration(configurations ...string) ServiceLoadOption {
+	return func(o *Service) {
+		for _, configuration := range configurations {
+			if configuration != "" {
+				o.Configuration = configuration
+				break
+			}
+		}
+	}
+}
+
 // LoadService loads configuration for a Cloud Run service from environment
 // variables. It returns a Service containing the loaded configuration or
 // ErrEnvironmentProcess if environment variable processing fails and/or
-// ErrInvalidPort if the PORT environment variable is set to 0.
+// ErrInvalidPort if the PORT environment variable is set to 0. Use options to
+// specify default values for the service.
 func LoadService(opts ...ServiceLoadOption) (*Service, error) {
-	s := &Service{}
-	return s, s.Reload(opts...)
+	// Default values
+	s := defaultService()
+
+	// Apply options
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	// Reload configuration from the environment
+	if err := s.Reload(); err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }
 
 // Reload reloads the configuration for a Cloud Run service from environment
 // variables. It returns ErrEnvironmentProcess if environment variable
 // processing fails and/or ErrInvalidPort if the PORT environment variable is
-// set to 0.
-func (s *Service) Reload(opts ...ServiceLoadOption) error {
-	loadOpts := defaultServiceLoadOptions()
-	for _, opt := range opts {
-		opt(&loadOpts)
+// set to 0. It does not overwrite values already set in the Service struct if
+// they are not set in the environment.
+func (s *Service) Reload() error {
+	if name := os.Getenv("K_SERVICE"); name != "" {
+		s.Name = name
 	}
 
-	s.Name = os.Getenv("K_SERVICE")
-	s.Revision = os.Getenv("K_REVISION")
-	s.Configuration = os.Getenv("K_CONFIGURATION")
+	if revision := os.Getenv("K_REVISION"); revision != "" {
+		s.Revision = revision
+	}
 
-	if s.Name == "" {
-		s.Name = loadOpts.defaultName
-	}
-	if s.Revision == "" {
-		s.Revision = loadOpts.defaultRevision
-	}
-	if s.Configuration == "" {
-		s.Configuration = loadOpts.defaultConfiguration
+	if configuration := os.Getenv("K_CONFIGURATION"); configuration != "" {
+		s.Configuration = configuration
 	}
 
 	if portStr := os.Getenv("PORT"); portStr != "" {
@@ -158,14 +161,36 @@ func (s *Service) Reload(opts ...ServiceLoadOption) error {
 		if err != nil {
 			return errors.Join(ErrEnvironmentProcess, ErrInvalidPort, err)
 		}
+		if port == 0 {
+			return fmt.Errorf("%w: PORT value cannot be 0", ErrInvalidPort)
+		}
 		s.Port = uint16(port)
-	} else {
-		s.Port = loadOpts.defaultPort
-	}
-
-	if s.Port == 0 {
-		return fmt.Errorf("%w: PORT value cannot be 0", ErrInvalidPort)
 	}
 
 	return nil
+}
+
+// EnvDecode implements the [envconfig.DecoderCtx] interface from
+// github.com/sethvargo/go-envconfig. This ensures that [envconfig.Process] will
+// return errors derived from [ErrEnvironmentProcess] and [ErrInvalidPort] if
+// the environment variables are invalid.
+//
+// The behavior of this function is equivalent to initializing a Service with
+// the default values and then calling [Service.Reload]. However, values already
+// set in the Service struct prior to calling this function are not overridden
+// by the defaults, only by the reloaded values from the environment.
+//
+// [envconfig.DecoderCtx]: https://pkg.go.dev/github.com/sethvargo/go-envconfig#DecoderCtx
+// [envconfig.Process]: https://pkg.go.dev/github.com/sethvargo/go-envconfig#Process
+func (s *Service) EnvDecode(ctx context.Context, val string) error {
+	defaults := defaultService()
+
+	// Name, Revision and Configuration default values are empty by default and
+	// can be skipped.
+
+	if s.Port == 0 {
+		s.Port = defaults.Port
+	}
+
+	return s.Reload()
 }


### PR DESCRIPTION
Closes #6 

This pull request introduces significant improvements to the `runcfg` library by refactoring the `Job` and `Metadata` structures, simplifying their default handling and loading mechanisms, and adding better integration with external tools like `go-envconfig`. Additionally, it enhances the documentation and examples in the `README.md` file.

### Enhancements to `Job` handling:
* Refactored the `Job` struct to include detailed documentation for Cloud Run job-related environment variables and replaced the `jobLoadOptions` struct with direct usage of the `Job` struct for default handling. (`job.go`, [[1]](diffhunk://#diff-d25200def3804ad5276ed9f6b2e57f0681afe30e7b1929ccd2dacda060b920c2R4-R58) [[2]](diffhunk://#diff-d25200def3804ad5276ed9f6b2e57f0681afe30e7b1929ccd2dacda060b920c2L60-R134)
* Simplified the `LoadJob` and `Reload` methods to remove redundant default handling logic and ensure environment variables are only applied when set. (`job.go`, [[1]](diffhunk://#diff-d25200def3804ad5276ed9f6b2e57f0681afe30e7b1929ccd2dacda060b920c2L60-R134) [[2]](diffhunk://#diff-d25200def3804ad5276ed9f6b2e57f0681afe30e7b1929ccd2dacda060b920c2L146-L147)
* Added `EnvDecode` method to integrate with `go-envconfig`, allowing seamless processing of environment variables with error handling. (`job.go`, [job.goL166-R187](diffhunk://#diff-d25200def3804ad5276ed9f6b2e57f0681afe30e7b1929ccd2dacda060b920c2L166-R187))

### Enhancements to `Metadata` handling:
* Refactored the `Metadata` struct to include detailed documentation for Cloud Run metadata server fields and replaced the `metadataLoadOptions` struct with direct usage of the `Metadata` struct for default handling. (`metadata.go`, [[1]](diffhunk://#diff-a8d12f1d7ad57b8d9b990ae8f5ca23a5a4673b4c513d1457f6896417dc2e00ddL76-R118) [[2]](diffhunk://#diff-a8d12f1d7ad57b8d9b990ae8f5ca23a5a4673b4c513d1457f6896417dc2e00ddL156-L188)
* Simplified the `LoadMetadata` and `Reload` methods to remove redundant default handling logic and ensure metadata fields are only applied when explicitly requested. (`metadata.go`, [[1]](diffhunk://#diff-a8d12f1d7ad57b8d9b990ae8f5ca23a5a4673b4c513d1457f6896417dc2e00ddL201-R213) [[2]](diffhunk://#diff-a8d12f1d7ad57b8d9b990ae8f5ca23a5a4673b4c513d1457f6896417dc2e00ddL291-L292)

### Documentation updates:
* Updated the `README.md` file to include an example of loading job configuration with default options and added a reference to the integration with `go-envconfig`. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R70)