### PR TITLE
Add Dependabot configuration for GitHub Actions and pin external actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,3 +14,17 @@ updates:
       major:
         update-types:
           - major
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      patch:
+        update-types:
+          - patch
+      minor:
+        update-types:
+          - minor
+      major:
+        update-types:
+          - major

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -65,7 +65,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -93,6 +93,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This pull request introduces updates to the Dependabot configuration and the CodeQL workflow to improve dependency management and ensure the use of specific, stable versions of GitHub Actions.

### Dependency Management Updates:
* [`.github/dependabot.yaml`](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR17-R30): Added a new configuration for `github-actions` to group updates by patch, minor, and major versions, with a weekly update schedule.

### CodeQL Workflow Enhancements:
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L58-R58): Updated the `actions/checkout` action to use a specific commit (`11bd71901bbe5b1630ceea73d27597364c9af683`) instead of a version tag (`v4`).
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L68-R68): Updated the `github/codeql-action/init` action to use a specific commit (`60168efe1c415ce0f5521ea06d5c2062adbeed1b`) instead of a version tag (`v3`).
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L96-R96): Updated the `github/codeql-action/analyze` action to use the same specific commit (`60168efe1c415ce0f5521ea06d5c2062adbeed1b`) for consistency.