### PR TITLE
Enhance resource creation by adding support for custom attributes

### DIFF
--- a/otelcfg/resources.go
+++ b/otelcfg/resources.go
@@ -2,15 +2,32 @@ package otelcfg
 
 import (
 	"github.com/joaopenteado/runcfg"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 )
 
-// NewServiceResource creates a new OpenTelemetry resource for a Cloud Run service.
-func NewServiceResource(metadata *runcfg.Metadata, service *runcfg.Service) *resource.Resource {
-	return resource.NewWithAttributes(
-		semconv.SchemaURL,
+type resourceConfig struct {
+	attrs []attribute.KeyValue
+}
 
+type ResourceOption = option[resourceConfig]
+
+// WithAttributes sets additional attributes for the resource.
+func WithAttributes(attrs ...attribute.KeyValue) ResourceOption {
+	return optionFunc[resourceConfig](func(cfg *resourceConfig) {
+		cfg.attrs = append(cfg.attrs, attrs...)
+	})
+}
+
+// NewServiceResource creates a new OpenTelemetry resource for a Cloud Run service.
+func NewServiceResource(metadata *runcfg.Metadata, service *runcfg.Service, opts ...ResourceOption) *resource.Resource {
+	cfg := &resourceConfig{}
+	for _, opt := range opts {
+		opt.apply(cfg)
+	}
+
+	attrs := append(cfg.attrs,
 		// https://github.com/open-telemetry/opentelemetry-go-contrib/blob/f368d047b7c605a7805094537a6922db36eabcdc/detectors/gcp/detector.go#L35
 		semconv.CloudProviderGCP,
 		semconv.CloudAccountID(metadata.ProjectID),
@@ -20,13 +37,21 @@ func NewServiceResource(metadata *runcfg.Metadata, service *runcfg.Service) *res
 		semconv.FaaSInstance(metadata.InstanceID),
 		semconv.CloudRegion(metadata.Region),
 	)
+
+	return resource.NewWithAttributes(
+		semconv.SchemaURL,
+		attrs...,
+	)
 }
 
 // NewJobResource creates a new OpenTelemetry resource for a Cloud Run job.
-func NewJobResource(metadata *runcfg.Metadata, job *runcfg.Job) *resource.Resource {
-	return resource.NewWithAttributes(
-		semconv.SchemaURL,
+func NewJobResource(metadata *runcfg.Metadata, job *runcfg.Job, opts ...ResourceOption) *resource.Resource {
+	cfg := &resourceConfig{}
+	for _, opt := range opts {
+		opt.apply(cfg)
+	}
 
+	attrs := append(cfg.attrs,
 		// https://github.com/open-telemetry/opentelemetry-go-contrib/blob/f368d047b7c605a7805094537a6922db36eabcdc/detectors/gcp/detector.go#L35
 		semconv.CloudProviderGCP,
 		semconv.CloudAccountID(metadata.ProjectID),
@@ -36,5 +61,10 @@ func NewJobResource(metadata *runcfg.Metadata, job *runcfg.Job) *resource.Resour
 		semconv.GCPCloudRunJobExecution(job.Execution),
 		semconv.GCPCloudRunJobTaskIndex(int(job.TaskIndex)),
 		semconv.CloudRegion(metadata.Region),
+	)
+
+	return resource.NewWithAttributes(
+		semconv.SchemaURL,
+		attrs...,
 	)
 }


### PR DESCRIPTION
This pull request introduces a more flexible configuration system for creating OpenTelemetry resources in the `otelcfg` package. The changes allow additional attributes to be passed dynamically to resource creation functions, improving extensibility and customization.

### Enhancements to resource configuration:

* Added a new `resourceConfig` type and `ResourceOption` type alias to support dynamic resource configuration through options. This includes the `WithAttributes` function to set additional attributes for resources. (`otelcfg/resources.go`, [otelcfg/resources.goR5-R30](diffhunk://#diff-f54db89aec7b23de0fbd30c7490c99719695b146c661967949798ce474db76d1R5-R30))

* Updated the `NewServiceResource` function to accept variadic `ResourceOption` arguments, enabling dynamic configuration of resource attributes. (`otelcfg/resources.go`, [otelcfg/resources.goR5-R30](diffhunk://#diff-f54db89aec7b23de0fbd30c7490c99719695b146c661967949798ce474db76d1R5-R30))

* Updated the `NewJobResource` function to also accept variadic `ResourceOption` arguments, aligning it with the new flexible configuration system. (`otelcfg/resources.go`, [[1]](diffhunk://#diff-f54db89aec7b23de0fbd30c7490c99719695b146c661967949798ce474db76d1L23-R54) [[2]](diffhunk://#diff-f54db89aec7b23de0fbd30c7490c99719695b146c661967949798ce474db76d1R65-R69)