### PR TITLE
Fix method receiver for zerolog Hook in zerologcfg to use pointer receiver

### DIFF
--- a/zerologcfg/log.go
+++ b/zerologcfg/log.go
@@ -61,7 +61,7 @@ func Hook(projectID string) zerolog.Hook {
 	return &cloudLoggingHook{ProjectID: projectID}
 }
 
-func (h cloudLoggingHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+func (h *cloudLoggingHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
 	// https://cloud.google.com/logging/docs/structured-logging
 
 	// CallerSkipFrameCount is the number of stack frames to skip to find the


### PR DESCRIPTION
This pull request includes a small but important change to the `zerologcfg/log.go` file. The change modifies the `Run` method of the `cloudLoggingHook` type to use a pointer receiver instead of a value receiver, likely to ensure proper handling of the struct's state.