### PR TITLE
Add HTTP middleware to inject zerolog.Logger into request context

### DIFF
--- a/zerologcfg/log.go
+++ b/zerologcfg/log.go
@@ -1,6 +1,7 @@
 package zerologcfg
 
 import (
+	"net/http"
 	"runtime"
 	"strconv"
 	"strings"
@@ -87,5 +88,22 @@ func (h *cloudLoggingHook) Run(e *zerolog.Event, level zerolog.Level, msg string
 		e.Str("logging.googleapis.com/trace", "projects/"+h.ProjectID+"/traces/"+span.TraceID().String())
 		e.Str("logging.googleapis.com/spanId", span.SpanID().String())
 		e.Bool("logging.googleapis.com/trace_sampled", span.TraceFlags().IsSampled())
+	}
+}
+
+// Handler returns a middleware that adds the zerolog logger to the request
+// context. It works very similarily to hlog.NewHandler with the difference that
+// it adds the request context to the logger. This is especially important for
+// tracing, where the request context is used to trace the request through the
+// system. Ensure that this middleware is ran after any other middleware that
+// injects tracing information to the request context.
+func Handler(logger zerolog.Logger) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			logger := logger.With().Ctx(ctx).Logger()
+			r = r.WithContext(logger.WithContext(ctx))
+			next.ServeHTTP(w, r)
+		})
 	}
 }


### PR DESCRIPTION
This commit introduces a new `Handler` function in the zerologcfg package, which serves as middleware to add the zerolog logger to the request context. This enhancement ensures that log messages within HTTP handlers can automatically include trace information. Additionally, the README has been updated to include usage examples for the new middleware, emphasizing the importance of its placement in relation to other middleware that may add tracing information.